### PR TITLE
Shader module reuse

### DIFF
--- a/SharpVk.HelloTriangle/Program.cs
+++ b/SharpVk.HelloTriangle/Program.cs
@@ -112,7 +112,7 @@ namespace SharpVk.HelloTriangle
         {
             this.device.WaitIdle();
 
-            commandPool.FreeCommandBuffers(commandBuffers);
+            this.commandPool.FreeCommandBuffers(commandBuffers);
 
             foreach (var frameBuffer in this.frameBuffers)
             {

--- a/SharpVk.HelloTriangle/Program.cs
+++ b/SharpVk.HelloTriangle/Program.cs
@@ -507,13 +507,13 @@ namespace SharpVk.HelloTriangle
                             new PipelineShaderStageCreateInfo
                             {
                                 Stage = ShaderStageFlags.Vertex,
-                                Module = vertShader,
+                                Module = this.vertShader,
                                 Name = "main"
                             },
                             new PipelineShaderStageCreateInfo
                             {
                                 Stage = ShaderStageFlags.Fragment,
-                                Module = fragShader,
+                                Module = this.fragShader,
                                 Name = "main"
                             }
                         }

--- a/SharpVk.HelloTriangle/Program.cs
+++ b/SharpVk.HelloTriangle/Program.cs
@@ -47,6 +47,8 @@ namespace SharpVk.HelloTriangle
         private RenderPass renderPass;
         private PipelineLayout pipelineLayout;
         private Pipeline pipeline;
+        private ShaderModule fragShader;
+        private ShaderModule vertShader;
         private Framebuffer[] frameBuffers;
         private CommandPool commandPool;
         private CommandBuffer[] commandBuffers;
@@ -89,6 +91,7 @@ namespace SharpVk.HelloTriangle
             this.CreateSwapChain();
             this.CreateImageViews();
             this.CreateRenderPass();
+            this.CreateShaderModules();
             this.CreateGraphicsPipeline();
             this.CreateFrameBuffers();
             this.CreateCommandPool();
@@ -164,6 +167,12 @@ namespace SharpVk.HelloTriangle
                 frameBuffer.Dispose();
             }
             this.frameBuffers = null;
+
+            this.fragShader.Dispose();
+            this.fragShader = null;
+
+            this.vertShader.Dispose();
+            this.vertShader = null;
 
             this.pipeline.Dispose();
             this.pipeline = null;
@@ -395,25 +404,27 @@ namespace SharpVk.HelloTriangle
             });
         }
 
-        private void CreateGraphicsPipeline()
+
+        private void CreateShaderModules()
         {
             int codeSize;
             var vertShaderData = LoadShaderData(@".\Shaders\vert.spv", out codeSize);
 
-            var vertShader = device.CreateShaderModule(new ShaderModuleCreateInfo
-            {
+            this.vertShader = device.CreateShaderModule(new ShaderModuleCreateInfo {
                 Code = vertShaderData,
                 CodeSize = codeSize
             });
 
             var fragShaderData = LoadShaderData(@".\Shaders\frag.spv", out codeSize);
 
-            var fragShader = device.CreateShaderModule(new ShaderModuleCreateInfo
-            {
+            this.fragShader = device.CreateShaderModule(new ShaderModuleCreateInfo {
                 Code = fragShaderData,
                 CodeSize = codeSize
             });
+        }
 
+        private void CreateGraphicsPipeline()
+        {
             this.pipelineLayout = device.CreatePipelineLayout(new PipelineLayoutCreateInfo());
 
             this.pipeline = device.CreateGraphicsPipelines(null, new[]
@@ -508,8 +519,6 @@ namespace SharpVk.HelloTriangle
                         }
                     }
                 }).Single();
-            fragShader.Dispose();
-            vertShader.Dispose();
         }
 
         private void CreateFrameBuffers()

--- a/SharpVk.UniformBuffers/Program.cs
+++ b/SharpVk.UniformBuffers/Program.cs
@@ -543,7 +543,7 @@ namespace SharpVk.UniformBuffers
 
         private void CreateShaderModules()
         {
-            vertShader = ShanqShader.CreateVertexModule(this.device,
+            this.vertShader = ShanqShader.CreateVertexModule(this.device,
                                                             shanq => from input in shanq.GetInput<Vertex>()
                                                                      from ubo in shanq.GetBinding<UniformBufferObject>()
                                                                      let transform = ubo.Proj * ubo.View * ubo.Model
@@ -552,7 +552,7 @@ namespace SharpVk.UniformBuffers
                                                                          Colour = input.Colour
                                                                      });
 
-            fragShader = ShanqShader.CreateFragmentModule(this.device,
+            this.fragShader = ShanqShader.CreateFragmentModule(this.device,
                                                             shanq => from input in shanq.GetInput<FragmentInput>()
                                                                      from ubo in shanq.GetBinding<UniformBufferObject>()
                                                                      let colour = new vec4(input.Colour, 1)
@@ -658,13 +658,13 @@ namespace SharpVk.UniformBuffers
                             new PipelineShaderStageCreateInfo
                             {
                                 Stage = ShaderStageFlags.Vertex,
-                                Module = vertShader,
+                                Module = this.vertShader,
                                 Name = "main"
                             },
                             new PipelineShaderStageCreateInfo
                             {
                                 Stage = ShaderStageFlags.Fragment,
-                                Module = fragShader,
+                                Module = this.fragShader,
                                 Name = "main"
                             }
                         }

--- a/SharpVk.UniformBuffers/Program.cs
+++ b/SharpVk.UniformBuffers/Program.cs
@@ -149,7 +149,7 @@ namespace SharpVk.UniformBuffers
         {
             this.device.WaitIdle();
 
-            commandPool.FreeCommandBuffers(commandBuffers);
+            this.commandPool.FreeCommandBuffers(commandBuffers);
 
             foreach (var frameBuffer in this.frameBuffers)
             {

--- a/SharpVk.VertexBuffers/Program.cs
+++ b/SharpVk.VertexBuffers/Program.cs
@@ -460,14 +460,14 @@ namespace SharpVk.VertexBuffers
 
         private void CreateShaderModules()
         {
-            vertShader = ShanqShader.CreateVertexModule(this.device,
+            this.vertShader = ShanqShader.CreateVertexModule(this.device,
                                                             shanq => from input in shanq.GetInput<Vertex>()
                                                                      select new VertexOutput {
                                                                          Colour = input.Colour,
                                                                          Position = new vec4(input.Position, 0, 1)
                                                                      });
 
-            fragShader = ShanqShader.CreateFragmentModule(this.device,
+            this.fragShader = ShanqShader.CreateFragmentModule(this.device,
                                                             shanq => from input in shanq.GetInput<FragmentInput>()
                                                                      select new FragmentOutput {
                                                                          Colour = new vec4(input.Colour, 1)
@@ -565,13 +565,13 @@ namespace SharpVk.VertexBuffers
                             new PipelineShaderStageCreateInfo
                             {
                                 Stage = ShaderStageFlags.Vertex,
-                                Module = vertShader,
+                                Module = this.vertShader,
                                 Name = "main"
                             },
                             new PipelineShaderStageCreateInfo
                             {
                                 Stage = ShaderStageFlags.Fragment,
-                                Module = fragShader,
+                                Module = this.fragShader,
                                 Name = "main"
                             }
                         }

--- a/SharpVk.VertexBuffers/Program.cs
+++ b/SharpVk.VertexBuffers/Program.cs
@@ -134,7 +134,7 @@ namespace SharpVk.VertexBuffers
         {
             this.device.WaitIdle();
 
-            commandPool.FreeCommandBuffers(commandBuffers);
+            this.commandPool.FreeCommandBuffers(commandBuffers);
 
             foreach (var frameBuffer in this.frameBuffers)
             {

--- a/SharpVk.VertexBuffers/Program.cs
+++ b/SharpVk.VertexBuffers/Program.cs
@@ -62,6 +62,8 @@ namespace SharpVk.VertexBuffers
         private RenderPass renderPass;
         private PipelineLayout pipelineLayout;
         private Pipeline pipeline;
+        private ShaderModule fragShader;
+        private ShaderModule vertShader;
         private Framebuffer[] frameBuffers;
         private CommandPool transientCommandPool;
         private CommandPool commandPool;
@@ -109,6 +111,7 @@ namespace SharpVk.VertexBuffers
             this.CreateSwapChain();
             this.CreateImageViews();
             this.CreateRenderPass();
+            this.CreateShaderModules();
             this.CreateGraphicsPipeline();
             this.CreateFrameBuffers();
             this.CreateCommandPools();
@@ -192,6 +195,12 @@ namespace SharpVk.VertexBuffers
                 frameBuffer.Dispose();
             }
             this.frameBuffers = null;
+
+            this.fragShader.Dispose();
+            this.fragShader = null;
+
+            this.vertShader.Dispose();
+            this.vertShader = null;
 
             this.pipeline.Dispose();
             this.pipeline = null;
@@ -449,23 +458,24 @@ namespace SharpVk.VertexBuffers
             });
         }
 
+        private void CreateShaderModules()
+        {
+            vertShader = ShanqShader.CreateVertexModule(this.device,
+                                                            shanq => from input in shanq.GetInput<Vertex>()
+                                                                     select new VertexOutput {
+                                                                         Colour = input.Colour,
+                                                                         Position = new vec4(input.Position, 0, 1)
+                                                                     });
+
+            fragShader = ShanqShader.CreateFragmentModule(this.device,
+                                                            shanq => from input in shanq.GetInput<FragmentInput>()
+                                                                     select new FragmentOutput {
+                                                                         Colour = new vec4(input.Colour, 1)
+                                                                     });
+        }
+
         private void CreateGraphicsPipeline()
         {
-            var vertShader = ShanqShader.CreateVertexModule(this.device,
-                                                            shanq => from input in shanq.GetInput<Vertex>()
-                                                                        select new VertexOutput
-                                                                        {
-                                                                            Colour = input.Colour,
-                                                                            Position = new vec4(input.Position, 0, 1)
-                                                                        });
-
-            var fragShader = ShanqShader.CreateFragmentModule(this.device,
-                                                                shanq => from input in shanq.GetInput<FragmentInput>()
-                                                                            select new FragmentOutput
-                                                                            {
-                                                                                Colour = new vec4(input.Colour, 1)
-                                                                            });
-
             var bindingDescription = Vertex.GetBindingDescription();
             var attributeDescriptions = Vertex.GetAttributeDescriptions();
 
@@ -567,8 +577,6 @@ namespace SharpVk.VertexBuffers
                         }
                     }
                 }).Single();
-            fragShader.Dispose();
-            vertShader.Dispose();
         }
 
         private void CreateFrameBuffers()


### PR DESCRIPTION
Its breaking vulkan-tutorial look by introducing new method in InitialiseVulkan(), but I think it's better than inserting `if (shaderModule == null)` before ShaderModules creating.